### PR TITLE
Fix/objectid matching multiple documents

### DIFF
--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -149,8 +149,15 @@ func (d Discover) matchLink(ctx context.Context, ls []Link) ([]Link, error) {
 					}
 
 					if exists {
-						ch <- fmt.Sprintf("%s.%s", db, cl)
-						cancel()
+						/**
+						Have to select to prevent multiple matching to block the channel.
+						With some weird setup it's possible to have a single ObjectID that match multiple document in different sources
+						*/
+						select {
+						case ch <- fmt.Sprintf("%s.%s", db, cl):
+							cancel()
+						case <-withCancel.Done():
+						}
 					}
 				}()
 			}


### PR DESCRIPTION
If the targeted database contains some documents with the same objectID, the matcher will hang because of a write in a channel.
This cause the entire program to hang.
With this fix, we keep only the first match and ignore all potential others.